### PR TITLE
Added IE 8,9 support. Removed height unit. Set listener to window.

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -6,14 +6,16 @@ define([], function () {
             if (link) {
                 var iframe = document.createElement('iframe');
                 iframe.style.width = '100%';
-                iframe.style.height = '500px'; // default height
                 iframe.style.border = 'none';
+                iframe.height = '500'; // default height
                 iframe.src = link.href;
 
-                // Listen for requests from the iframe
-                iframe.addEventListener('message', function(message) {
+                // Listen for requests from the window
+                window.addEventListener('message', function(event) {
+                    var message = JSON.parse(event.data); // IE 8 + 9 only support strings
+
                     if (message.type === 'set-height') {
-                        iframe.height = message.value + 'px';
+                        iframe.height = message.value;
                     } else if (message.type === 'navigate') {
                         document.location.href = message.value;
                     } else {


### PR DESCRIPTION
For some reason I no longer have write access to Guardian ;_; so here's a fork ----E

IE 8, 9 can only receive postMessage data as a string, so we JSON.strigify and parse it.

Event listener is now set on window not the iframe element.
