### PR TITLE
Replace link with iframe, else append might append below caption

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -24,8 +24,8 @@ define([], function () {
                 }, false);
 
                 // Replace link with iframe
-                el.removeChild(link); // assumed to be direct child
-                el.appendChild(iframe);
+                // Note: link is assumed to be a direct child
+                el.replaceChild(iframe, link);
             } else {
                 console.warn('iframe-wrapper applied to element without any link');
             }


### PR DESCRIPTION
I noticed this morning that if the interactive figure contains a caption, the boot script appends the iframe so it appears below the caption, rather than above.

@andymason @commuterjoy want to give this a look before I merge? It's a bit cumbersome to test changes to this script without deploying, annoyingly...
