### PR TITLE
Added check for source of message allowing for multiple iframes

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -16,7 +16,13 @@ define([], function () {
                         return;
                     }
 
-                    var message = JSON.parse(event.data); // IE 8 + 9 only support strings
+                    // IE 8 + 9 only support strings
+                    var message = JSON.parse(event.data);
+
+                    // Restrict message events to source iframe
+                    if (!message.href || message.href !== link.href) {
+                        return;
+                    }
 
                     if (message.type === 'set-height') {
                         iframe.height = message.value;


### PR DESCRIPTION
Currently if multiple iframe interactives are loaded on a single page they will all receive each other's messages.

I suggest the inclusion  of the href within the message data to compare against the link's original href.

It would be possible to use the `event.source.location.href`, however, this might change within the child iframe if #hashes were added or navigating to a sub folder.

This change would require a version bump as existing interactives would break. Or, all existing interactives could upgraded to use the new iframeMessenger library.
