### PR TITLE
Compare event.source instead of passed href string

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -18,17 +18,13 @@ define([], function () {
 
                 // Listen for requests from the window
                 window.addEventListener('message', function(event) {
-                    if (event.origin !== 'http://interactive.guim.co.uk') {
+                    if (event.origin !== 'http://interactive.guim.co.uk' ||
+                        event.source !== iframe.contentWindow) {
                         return;
                     }
 
                     // IE 8 + 9 only support strings
                     var message = JSON.parse(event.data);
-
-                    // Restrict message events to source iframe
-                    if (event.source !== iframe.contentWindow) {
-                        return;
-                    }
 
                     // Actions
                     switch (message.type) {


### PR DESCRIPTION
Some interactives have been embedded without a trailing slash which S3 kindly adds if there's an index.html. However, this will fail the href test. The change replaces that check with the event.source (aka the iframe's window) against the created iframe element's contentWindow.

The change also has the added benefit of removing the need to pass the href along with the data as a string.
