### PR TITLE
Require Signin

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -42,9 +42,12 @@ define([], function () {
                 iframe = document.createElement('iframe');
                 iframe.style.width = '100%';
                 iframe.style.border = 'none';
-                iframe.height = '500'; // default height
+                iframe.style.overflow = 'hidden';
+                iframe.height = '150'; // default height so that no-script iframes aren't super high
                 iframe.src = link.href;
                 iframe.className = link.className;
+                iframe.seamless = 'seamless';
+                iframe.scrolling = 'no';
 
                 // Listen for requests from the window
                 window.addEventListener('message', function(event) {


### PR DESCRIPTION
This PR adds url matching based on the link source url to allow iframes to run off different domains.

It also adds functionality that, if the class `.js-request-user-signin` is detected on the link element, will require the user to be signed in to view the iframe. It also takes care of displaying a signin link and revealing signin help text if provided.

The relevant areas in composer can be found via this PR: https://github.com/guardian/flexible-content/pull/727
