### PR TITLE
Return parent page width

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -41,6 +41,7 @@ define([], function () {
                             _postMessage({
                                 'iframeTop':    iframe.getBoundingClientRect().top,
                                 'innerHeight':  window.innerHeight,
+                                'innerWidth':   window.innerWidth,
                                 'pageYOffset':  window.pageYOffset
                             });
                             break;


### PR DESCRIPTION
Media queries inside the iframe don't extend to the parent page. Therefore, we can request the parent width manually.
