### PR TITLE
Remove origin check to allow third-party use of boot script

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -18,8 +18,7 @@ define([], function () {
 
                 // Listen for requests from the window
                 window.addEventListener('message', function(event) {
-                    if (event.origin !== 'http://interactive.guim.co.uk' ||
-                        event.source !== iframe.contentWindow) {
+                    if (event.source !== iframe.contentWindow) {
                         return;
                     }
 


### PR DESCRIPTION
As discussed by email, the source check should be enough and that allows others (e.g. Infostrada) to use this script.

/cc @andymason 
