### PR TITLE
Access parent window's location information

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -5,8 +5,7 @@ define([], function () {
             var iframe;
             var link = el.querySelector('a[href]');
 
-            function _postMessage(message, id) {
-                message.id = id;
+            function _postMessage(message) {
                 iframe.contentWindow.postMessage(JSON.stringify(message), '*');
             }
 
@@ -39,6 +38,8 @@ define([], function () {
                             break;
                         case 'get-location':
                             _postMessage({
+                                'id':       message.id,
+                                'type':     message.type,
                                 'hash':     window.location.hash,
                                 'host':     window.location.host,
                                 'hostname': window.location.hostname,
@@ -52,11 +53,13 @@ define([], function () {
                             break;
                         case 'get-position':
                             _postMessage({
+                                'id':           message.id,
+                                'type':         message.type,
                                 'iframeTop':    iframe.getBoundingClientRect().top,
                                 'innerHeight':  window.innerHeight,
                                 'innerWidth':   window.innerWidth,
                                 'pageYOffset':  window.pageYOffset
-                            }, message.id);
+                            });
                             break;
                         default:
                            console.error('Received unknown action from iframe: ', message);


### PR DESCRIPTION
Iframed interactives need access to the location #hash and query strings to support deep linking and sharing of custom views. This new method returns a copy the parent page's document.location properties.

To support additional post message methods and ID is now provided and returned allowing the receiving client to identify the response.
