### PR TITLE
Add visibility tracking

### DIFF
--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -6,6 +6,19 @@ define([], function () {
             var isVisible;
             var link = el.querySelector('a[href]');
 
+            // Calls func on trailing edge of the wait period
+            function _debounce(func, wait) {
+                var timeout;
+                return function() {
+                    var context = this, args = arguments;
+                    var later = function() {
+                        func.apply(context, args);
+                    };
+                    clearTimeout(timeout);
+                    timeout = setTimeout(later, wait);
+                };
+            };
+
             function _postMessage(message) {
                 iframe.contentWindow.postMessage(JSON.stringify(message), '*');
             }
@@ -106,12 +119,12 @@ define([], function () {
                             });
 
                             // Send updated visibility if and when it changes
-                            window.addEventListener('scroll', function(ev) {
+                            window.addEventListener('scroll', _debounce(function(ev) {
                                 _postMessageOnVisibilityChange(message.threshold);
-                            });
-                            window.addEventListener('resize', function(ev) {
+                            }, 50));
+                            window.addEventListener('resize', _debounce(function(ev) {
                                 _postMessageOnVisibilityChange(message.threshold);
-                            });
+                            }, 50));
                             break;
                     }
                 }, false);

--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -3,10 +3,46 @@ define([], function () {
         boot: function (el, context, config, mediator) {
             // Extract href of the first link in the content, if any
             var iframe;
+            var isVisible;
             var link = el.querySelector('a[href]');
 
             function _postMessage(message) {
                 iframe.contentWindow.postMessage(JSON.stringify(message), '*');
+            }
+
+            // threshold represents the fraction of the element that must be in the
+            // viewport before it is considered visible.
+            // e.g. 0.5 means that half the height or width must be in the viewport
+            //      1 means that the entire element must be in the viewport
+            //      (defaults to 1)
+            function _isVisible(threshold) {
+                var threshold = threshold || 1;
+                var box = el.getBoundingClientRect();
+                var width = box.right - box.left;
+                var height = box.bottom - box.top;
+                var windowHeight = window.innerHeight || document.documentElement.clientHeight;
+                var windowWidth = window.innerWidth || document.documentElement.clientWidth;
+                return (
+                    box.left >= -(width * (1 - threshold)) &&
+                    box.top >= -(height * (1 - threshold)) &&
+                    box.right <= windowWidth + (width * (1 - threshold)) &&
+                    box.bottom <= windowHeight + (height * (1 - threshold))
+                );
+            }
+
+            function _hasVisibilityChanged(threshold) {
+                var wasVisible = isVisible;
+                isVisible = _isVisible(threshold);
+                return (wasVisible !== isVisible);
+            }
+
+            function _postMessageOnVisibilityChange(threshold) {
+                if (_hasVisibilityChanged(threshold)) {
+                    _postMessage({
+                        'type': 'visibility',
+                        'visible': isVisible
+                    });
+                }
             }
 
             if (link) {
@@ -61,12 +97,28 @@ define([], function () {
                                 'pageYOffset':  window.pageYOffset
                             });
                             break;
+                        case 'monitor-visibility':
+                            // Send initial visibility value
+                            _postMessage({
+                                'type': 'visibility',
+                                'visible': _isVisible(message.threshold)
+                            });
+
+                            // Send updated visibility if and when it changes
+                            window.addEventListener('scroll', function(ev) {
+                                _postMessageOnVisibilityChange(message.threshold);
+                            });
+                            window.addEventListener('resize', function(ev) {
+                                _postMessageOnVisibilityChange(message.threshold);
+                            });
+                            break;
                     }
                 }, false);
 
                 // Replace link with iframe
                 // Note: link is assumed to be a direct child
                 el.replaceChild(iframe, link);
+
             } else {
                 console.warn('iframe-wrapper applied to element without any link');
             }

--- a/iframe-wrapper/boot.js
+++ b/iframe-wrapper/boot.js
@@ -99,9 +99,10 @@ define([], function () {
                             break;
                         case 'monitor-visibility':
                             // Send initial visibility value
+                            isVisible = _isVisible(message.threshold);
                             _postMessage({
                                 'type': 'visibility',
-                                'visible': _isVisible(message.threshold)
+                                'visible': isVisible
                             });
 
                             // Send updated visibility if and when it changes


### PR DESCRIPTION
We're using embedded interactives as part of some new membership feature tests, and we'd like to be able to track their visibility - i.e. whether enough of the element is in the viewport for long enough to be considered "visible".

This can't be tracked from within the iframe itself because it doesn't know about the size of the parent viewport, hence the changes needed to this boot script. The approach I've gone for is that the iframe will opt in to this visibility monitoring by sending a `monitor-visibility` message to the parent. (This message will be sent using the `iframeMessenger` - separate PR to come.) The parent then tells the iframe its initial visibility and sets up handlers to message it with an updated value if the visibility changes as a result of `scroll` or `resize` events.


